### PR TITLE
wegen css problem bei falschem login

### DIFF
--- a/platonic_snake/WebContent/jsp/Login/NotWelcome.jsp
+++ b/platonic_snake/WebContent/jsp/Login/NotWelcome.jsp
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<base href="${pageContext.request.requestURI}" />
+	<meta charset="ISO-8859-1">
+	<link rel="stylesheet" href="../../css/style1.css" type="text/css">
+	<title>Fehler</title>
+</head>
+<body>
+
+<%@ includefile="/jsp/Fragments/header.jspf" %>
+
+<div class = "left">
+	<br>
+</div>
+
+<main>
+	<div class = "ausrichtung">
+		<div class = "formularfeld">
+			<h1>Au Weia !</h1>
+			<p>Das war Wohl nichts. Probier es <a href="/LogIn.jsp">noch mal</a> ;) oder registrier dich <a href="../Create/GetData.jsp">hier</a>.</p>
+		</div>
+	</div>
+</main>
+
+<div class = "right">
+	<br>
+</div>
+
+<%@ includefile="/jsp/Fragments/footer.jspf" %>
+
+</body>
+</html>


### PR DESCRIPTION
Mit dieser else methode im servlet könnten wir das css problem umgehen, wenn falsche zugangsdaten eingegeben wurden. Bei include lädt das css nicht auch mit dem base tag nicht. mit ner neuen seite und forward würde es klappen. alternativ trotzdem auf login verlinken dann kommt aber keine antwort.

else{  
                System.out.println("[LOG] Wrong User");
                System.out.println(u); //E
                System.out.println(p); //E
                out.print("Sorry username or password error");  
                RequestDispatcher rd=request.getRequestDispatcher("jsp/Login/NotWelcome.jsp");  
                rd.forward(request,response);  
            }